### PR TITLE
Fix low-latency playback on Firefox and improve codec handling

### DIFF
--- a/server.c++
+++ b/server.c++
@@ -37,11 +37,6 @@ const int TIMESTAMP_SCALE = 1000; // Millisecond time base.
 
 const int LINESIZE_ALIGNMENT = 32;   // idk, internet told me so?
 
-static const uint8_t OPUS_DEFAULT_EXTRADATA[19] = {
-  'O', 'p', 'u', 's', 'H', 'e', 'a', 'd',
-  1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-};
-
 kj::String avError(int error) {
   char buffer[4096];
   av_strerror(error, buffer, sizeof(buffer));
@@ -344,8 +339,8 @@ void writeStream(kj::ArrayPtr<RingBuffer> ringBuffers, kj::OutputStream& out,
 
   AVCodecID codecId = AV_CODEC_ID_OPUS;
   if (filename.endsWith(".aac")) {
-    // TODO: AAC format doesn't seem to work. ffmpeg produces some sort of invalid output. I
-    // can't figure out why. So for now we make iPhone use mp3 (which sucks).
+    // TODO: AAC format doesn't work.
+    // It doesn't play on Chrome, and on Firefox the audio is slow and lags behind.
     codecId = AV_CODEC_ID_AAC;
   } else if (filename.endsWith(".mp3")) {
     codecId = AV_CODEC_ID_MP3;
@@ -356,28 +351,39 @@ void writeStream(kj::ArrayPtr<RingBuffer> ringBuffers, kj::OutputStream& out,
   AVChannelLayout layout = AV_CHANNEL_LAYOUT_MONO;
 
   AVStream* stream = avformat_new_stream(formatCtx, codec);
-  stream->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
-  stream->codecpar->sample_rate = 48000;
-  av_channel_layout_copy(&stream->codecpar->ch_layout, &layout);
-  stream->codecpar->format = AV_SAMPLE_FMT_FLT;
   stream->codecpar->codec_id = codecId;
-  if (codecId == AV_CODEC_ID_OPUS) {
-    stream->codecpar->bit_rate = 64000;
-    stream->codecpar->extradata = reinterpret_cast<uint8_t*>(av_malloc(19));
-    stream->codecpar->extradata_size = 19;
-    memcpy(stream->codecpar->extradata, OPUS_DEFAULT_EXTRADATA, 19);
-    stream->codecpar->extradata[9] = layout.nb_channels;  // REALLY???
-  } else if (codecId == AV_CODEC_ID_AAC) {
-    stream->codecpar->bit_rate = 0;
-
-    // This is the extradata my camera gives me idk.
-    stream->codecpar->extradata = reinterpret_cast<uint8_t*>(av_malloc(2));
-    stream->codecpar->extradata[0] = 17;
-    stream->codecpar->extradata[1] = 136;
-  } else if (codecId == AV_CODEC_ID_MP3) {
-    stream->codecpar->bit_rate = 64000;
-  }
+  stream->codecpar->codec_type = AVMEDIA_TYPE_AUDIO;
+  stream->codecpar->bit_rate = 64000;
+  stream->codecpar->sample_rate = 48000;
+  stream->codecpar->format = AV_SAMPLE_FMT_FLTP;
+  av_channel_layout_copy(&stream->codecpar->ch_layout, &layout);
   stream->time_base = {1, TIMESTAMP_SCALE};
+  if (codecId == AV_CODEC_ID_OPUS) {
+    // Opus extra data (19 bytes total).
+    uint8_t opus_header[] = {
+        'O', 'p', 'u', 's', 'H', 'e', 'a', 'd',    // Signature='OpusHead' (8 bytes)
+        0x01,                                      // Version=1
+        static_cast<uint8_t>(layout.nb_channels),  // Channels=1
+        0x00, 0x00,                                // Pre-skip=0
+        0x80, 0xBB, 0x00, 0x00,                    // Input sample rate=48000
+        0x00, 0x00,                                // Output gain=0
+        0x00                                       // Channel mapping family=0
+    };
+    stream->codecpar->extradata = (uint8_t*)av_memdup(opus_header, sizeof(opus_header));
+    stream->codecpar->extradata_size = sizeof(opus_header);
+  } else if (codecId == AV_CODEC_ID_AAC) {
+    // AAC extra data (2 bytes total).
+    uint8_t aac_header[] = {
+        0x12,                                         // Profile=AAC-LC(1<<3) | SamplingIndex=48kHz(4)
+        static_cast<uint8_t>(layout.nb_channels << 3) // Channel config
+    };
+    stream->codecpar->extradata = (uint8_t*)av_memdup(aac_header, sizeof(aac_header));
+    stream->codecpar->extradata_size = sizeof(aac_header);
+    stream->codecpar->profile = FF_PROFILE_AAC_LOW;
+  } else if (codecId == AV_CODEC_ID_MP3) {
+    // FLT (packed float) is optimal for legacy codecs, including MP3.
+    stream->codecpar->format = AV_SAMPLE_FMT_FLT;
+  }
 
   formatCtx->oformat = KJ_AVCALL(av_guess_format(nullptr, filename.cStr(), nullptr));
 
@@ -427,34 +433,25 @@ void writeStream(kj::ArrayPtr<RingBuffer> ringBuffers, kj::OutputStream& out,
   KJ_DEFER(av_packet_free(&packet));
 
   for (uint counter = 0; !state.disconnected; counter++) {
-    if (codecId == AV_CODEC_ID_AAC && counter >= 100) {
-      // TODO: I'm only returning 1s of audio for AAC for debugging reasons... once it actually
-      // works, remove the above.
-      KJ_AVCALL(avcodec_send_frame(codecCtx, nullptr));
-    } else {
-      auto samples = kj::arrayPtr(reinterpret_cast<float*>(frame->data[0]), frame->nb_samples);
-      for (auto i: kj::zeroTo(ringBuffers.size())) {
-        // Don't get more than 1s behind.
-        size_t maxLag = inputOffsets[i] == 0 ? 0 : frame->sample_rate * sizeof(float);
-        inputOffsets[i] = ringBuffers[i].read(inputOffsets[i], maxLag, samples.asBytes(), i > 0);
-      }
-
-      KJ_AVCALL(avcodec_send_frame(codecCtx, frame));
-
-      totalSamples += frame->nb_samples;
-      samplesSinceFlush += frame->nb_samples;
-
-      // This is a hack. Setting PTS correctly would look like this:
-      //
-      // frame->pts = totalSamples * TIMESTAMP_SCALE / frame->sample_rate;
-      //
-      // However DTS must be adjusted accordingly to avoid "Queue input is backward in time"
-      // warnings while streaming. Tweak both below, before sending each packet.
-      frame->pts = totalSamples;
+    auto samples = kj::arrayPtr(reinterpret_cast<float*>(frame->data[0]), frame->nb_samples);
+    for (auto i: kj::zeroTo(ringBuffers.size())) {
+      // Don't get more than 1s behind.
+      size_t maxLag = inputOffsets[i] == 0 ? 0 : frame->sample_rate * sizeof(float);
+      inputOffsets[i] = ringBuffers[i].read(inputOffsets[i], maxLag, samples.asBytes(), i > 0);
     }
 
-    // Note to self: To trigger EOF, do:
-    //   KJ_AVCALL(avcodec_send_frame(codecCtx, nullptr));
+    KJ_AVCALL(avcodec_send_frame(codecCtx, frame));
+
+    totalSamples += frame->nb_samples;
+    samplesSinceFlush += frame->nb_samples;
+
+    // This is a hack. Setting PTS correctly would look like this:
+    //
+    // frame->pts = totalSamples * TIMESTAMP_SCALE / frame->sample_rate;
+    //
+    // However DTS must be adjusted accordingly to avoid "Queue input is backward in time"
+    // warnings while streaming. Tweak both below, before sending each packet.
+    frame->pts = totalSamples;
 
     for (;;) {
       // Ask codec to deliver a packet into our reusable packet struct.

--- a/server.c++
+++ b/server.c++
@@ -607,10 +607,23 @@ public:
                 KJ_SYSCALL(ioctl(sock, FIONBIO, &opt));
               }
 
+              kj::StringPtr contentType;
+              if (filename.endsWith(".webm")) {
+                 contentType = "audio/webm; codecs=opus";
+              } else if (filename.endsWith(".ogg")) {
+                 contentType = "audio/ogg; codecs=opus";
+              } else if (filename.endsWith(".aac")) {
+                 contentType = "audio/mp4; codecs=\"mp4a.40.2\"";
+              } else if (filename.endsWith(".mp3")) {
+                 contentType = "audio/mpeg";
+              } else {
+                 KJ_FAIL_ASSERT("unknown audio format", filename);
+              }
+
               kj::FdOutputStream out(kj::mv(sock));
               auto headers = kj::str(
                   "HTTP/1.1 200 OK\r\n"
-                  "Content-Type: audio/ogg\r\n"
+                  "Content-Type: ", contentType, "\r\n"
                   "\r\n");
               out.write(headers.asBytes());
               writeStream(ringBuffers, out, filename);


### PR DESCRIPTION
The real highlight of this PR is in 255516013052b4233539cf27490c1098552cc4e7, which makes low-latency playback work on Firefox. Before, elapsed time would advance too quickly and nothing would play. Firefox seems to expect timestamps in milliseconds (that ffmpeg also defaults to), while other browsers are fine with the original raw sample-based timing.

The other two commits marginally improve codec setup and handling, but they don't bring anything new to the table. What I really wanted was to fix AAC compatibility, but despite getting it to play on Firefox and Safari (not Chrome though) I was unable to fix the audio playing a tad too slowly and lagging behind in the time I had allocated for it.

Submitting both changes together is a little lazy, but I worked on the latter on top of the former. If that bothers you, just let me know. :) I'll submit one at a time, no problem.